### PR TITLE
Build your own VM in the Cloud with AWS

### DIFF
--- a/en/binaries/build_your_own_openjdk.md
+++ b/en/binaries/build_your_own_openjdk.md
@@ -7,6 +7,6 @@ The below links cover build OpenJDK natively or in the cloud enviromnment for Li
 
 Go to the [Adopt OpenJDK - Build OpenJDK  page](https://java.net/projects/adoptopenjdk/pages/WhatToWorkOnForOpenJDK#Build_OpenJDK) to find out more about **building on other platforms**. 
 
-You can also follow these instructions to build it on the **cloud** environment as longs as your provision the appropriate environments and follow the instructions from the links above.
+You can also follow these instructions to build it on the [**cloud**](http://alimacsmusings.blogspot.com/2015/08/building-openjdk9-on-cloud-part-1.html) environment as long as you provision the appropriate environments and follow the instructions from the links above.
 
 Also see [Table of supported OSes & IDEs](../adopt-openjdk-getting-started/table_of_supported_oses_&_ides.md) and [Virtual Machines](../virtual-machines/virtual_machines.md).

--- a/en/binaries/build_your_own_openjdk.md
+++ b/en/binaries/build_your_own_openjdk.md
@@ -7,6 +7,6 @@ The below links cover build OpenJDK natively or in the cloud enviromnment for Li
 
 Go to the [Adopt OpenJDK - Build OpenJDK  page](https://java.net/projects/adoptopenjdk/pages/WhatToWorkOnForOpenJDK#Build_OpenJDK) to find out more about **building on other platforms**. 
 
-You can also follow these instructions to build it on the [**cloud**](http://alimacsmusings.blogspot.com/2015/08/building-openjdk9-on-cloud-part-1.html) environment as long as you provision the appropriate environments and follow the instructions from the links above.
+You can also follow these instructions to [build it on the **cloud** environment ](http://alimacsmusings.blogspot.com/2015/08/building-openjdk9-on-cloud-part-1.html) as long as you provision the appropriate environments and follow the instructions from the links above.
 
 Also see [Table of supported OSes & IDEs](../adopt-openjdk-getting-started/table_of_supported_oses_&_ides.md) and [Virtual Machines](../virtual-machines/virtual_machines.md).

--- a/en/virtual-machines/virtual_machines.md
+++ b/en/virtual-machines/virtual_machines.md
@@ -3,6 +3,6 @@
 * [Ready-made VM](ready-made_vm.md)
 * [Build your own VM](build_your_own_vm.md)
 * [Build your own light-weight VM](build_your_own_lightweight_vm.md)
-* [Build your own VM in the Cloud with AWS] ()
+* [Build your own VM in the Cloud with AWS] (http://alimacsmusings.blogspot.com/2015/08/building-openjdk9-on-cloud-part-1.html)
 * [Sharing host folder with guest VM](sharing_host_folder_with_guest_vm.md)
 * [OpenJDK 8 Vagrant Puppet ](adoptjdk_puppet_vm.md)

--- a/en/virtual-machines/virtual_machines.md
+++ b/en/virtual-machines/virtual_machines.md
@@ -3,5 +3,6 @@
 * [Ready-made VM](ready-made_vm.md)
 * [Build your own VM](build_your_own_vm.md)
 * [Build your own light-weight VM](build_your_own_lightweight_vm.md)
+* [Build your own VM in the Cloud with AWS] ()
 * [Sharing host folder with guest VM](sharing_host_folder_with_guest_vm.md)
 * [OpenJDK 8 Vagrant Puppet ](adoptjdk_puppet_vm.md)


### PR DESCRIPTION
Added "Build your own VM in the Cloud with AWS" to virtual_machines.md with a link to a blog detailing how to set up and use an Amazon Web Services EC2 VM.  For use on LJC Hackdays.